### PR TITLE
Add additional logging

### DIFF
--- a/ResumeUpload/index.js
+++ b/ResumeUpload/index.js
@@ -5,9 +5,10 @@ const { uploadResume } = require("./uploadResume");
 
 module.exports = async function(context, req) {
   const isAuthenticated = authenticateApiKey(context, req);
+  let jsonResponse = {};
 
   if (isAuthenticated === false) {
-    context.res = {
+    jsonResponse = {
       status: 401,
       body: {
         error: true,
@@ -15,6 +16,9 @@ module.exports = async function(context, req) {
         message: "Unable to authenticate request.",
       },
     };
+
+    context.log.error(JSON.stringify(jsonResponse, null, 2));
+    context.res = jsonResponse;
     context.done();
   }
 
@@ -26,8 +30,7 @@ module.exports = async function(context, req) {
         return result;
       })
       .catch(error => {
-        context.log.error(`${error}`);
-        context.res = {
+        jsonResponse = {
           status: 400,
           body: {
             error: true,
@@ -35,6 +38,9 @@ module.exports = async function(context, req) {
             message: `${error}`,
           },
         };
+
+        context.log.error(JSON.stringify(jsonResponse, null, 2));
+        context.res = jsonResponse;
         context.done();
       });
 
@@ -43,7 +49,7 @@ module.exports = async function(context, req) {
 
       await uploadResume(resume, email)
         .then(result => {
-          context.res = {
+          jsonResponse = {
             status: 200,
             body: {
               error: false,
@@ -51,6 +57,11 @@ module.exports = async function(context, req) {
               message: `Success: The file was uploaded successfully: ${result.Location}`,
             },
           };
+
+          //   Having this log is breaking tests due to Jest mocking complications. Should be fixed.
+          //   context.log(JSON.stringify(jsonResponse, null, 2));
+
+          context.res = jsonResponse;
           context.done();
         })
         .catch(error => {

--- a/ResumeUpload/index.js
+++ b/ResumeUpload/index.js
@@ -4,6 +4,9 @@ const { parseFormData } = require("./parseFormData");
 const { uploadResume } = require("./uploadResume");
 
 module.exports = async function(context, req) {
+  //   Log incoming request
+  context.log(req);
+
   const isAuthenticated = authenticateApiKey(context, req);
   let jsonResponse = {};
 
@@ -17,7 +20,7 @@ module.exports = async function(context, req) {
       },
     };
 
-    context.log.error(JSON.stringify(jsonResponse, null, 2));
+    context.log(JSON.stringify(jsonResponse, null, 2));
     context.res = jsonResponse;
     context.done();
   }
@@ -39,7 +42,7 @@ module.exports = async function(context, req) {
           },
         };
 
-        context.log.error(JSON.stringify(jsonResponse, null, 2));
+        context.log(JSON.stringify(jsonResponse, null, 2));
         context.res = jsonResponse;
         context.done();
       });
@@ -59,13 +62,12 @@ module.exports = async function(context, req) {
           };
 
           //   Having this log is breaking tests due to Jest mocking complications. Should be fixed.
-          //   context.log(JSON.stringify(jsonResponse, null, 2));
-
+          context.log(JSON.stringify(jsonResponse, null, 2));
           context.res = jsonResponse;
           context.done();
         })
         .catch(error => {
-          context.log.error(`Error occured during upload to S3: ${error}`);
+          context.log(`Error occured during upload to S3: ${error}`);
           context.res = {
             status: 500,
             body: {

--- a/tests/ResumeUpload/context.js
+++ b/tests/ResumeUpload/context.js
@@ -1,7 +1,5 @@
 module.exports = {
   res: jest.fn(),
   done: jest.fn(),
-  log: {
-    error: jest.fn(),
-  },
+  log: jest.fn(),
 };


### PR DESCRIPTION
It would be good to have logging of all requests and responses. 

There is an issue in the Jest tests where I couldn't figure out how to mock `context.log()` and `context.log.error()` when they're both used in the same test. To circumvent this I removed `error` from all logs. This is what I did the in the RequestTrigger code 